### PR TITLE
Update python to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.11-slim-buster
 
 ENV \
   # python:


### PR DESCRIPTION
Update to python 3.11 since 3.8 will be eol in october 2024.

Probably the dependencies can do with an upgrade as well. 