### PR TITLE
Multi ip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Usage: serviceregistrator [OPTIONS]
   Register docker containers as consul services
 
 Options:
-  -i, --ip TEXT                   address to use for services without
-                                  SERVICE_IP  [required]
+  -i, --ip TEXT                   address for services (IP or IP@TAG,
+                                  repeatable)  [required]
   -t, --tags TEXT                 comma-separated list of tags to append to
                                   all registered services
   -h, --consul-host TEXT          consul agent host  [default: 127.0.0.1]
@@ -216,9 +216,43 @@ docker run -d \
 
 ### Service IP
 
-The `--ip` command-line flag sets the default IP for all services. It can be
-overridden per-container with `SERVICE_IP` or per-port with
-`SERVICE_<port>_IP`.
+The `--ip` flag sets the default address for services. It can be specified
+multiple times and accepts an optional tag using the `IP@TAG` format:
+
+```bash
+serviceregistrator --ip 10.2.2.5                        # single IP, no tag
+serviceregistrator --ip 10.2.2.5@physical               # single IP with tag
+serviceregistrator --ip 10.2.2.5@physical --ip 10.10.10.5@virtual  # two IPs
+```
+
+The `@` separator is used instead of `:` to avoid conflicts with IPv6 addresses.
+
+When multiple `--ip` values are given, containers that listen on all interfaces
+(`0.0.0.0`) are registered once per `--ip` — creating multiple Consul service
+instances under the same service name, each with its own IP and health check.
+Containers that bind a specific IP are registered once with that IP.
+
+When a tag is provided, it is:
+
+- appended to the service's Consul tags (alongside `SERVICE_TAGS` and `--tags`)
+- included in the service ID (e.g., `host:container:8090:physical`)
+
+This lets consumers select a specific network using standard Consul mechanisms:
+
+- DNS: `physical.myapi.service.consul`
+- consul-template: `{{range service "myapi|physical"}}`
+- API: `/v1/health/service/myapi?tag=physical`
+
+The tag is always applied, even with a single `--ip`, enabling a smooth
+migration path:
+
+1. `--ip 10.2.2.5` — current setup, no change
+2. `--ip 10.2.2.5@physical` — tag is added, consumers can start filtering
+3. `--ip 10.2.2.5@physical --ip 10.10.10.5@virtual` — both networks active
+
+Per-container overrides with `SERVICE_IP` or `SERVICE_<port>_IP` still work.
+When a container overrides its IP, the tag from the matching `--ip` entry (if
+any) is applied.
 
 ### Service Alias
 
@@ -303,10 +337,11 @@ Common check options:
 
 The service ID is a cluster-wide unique identifier generated automatically:
 
-    <hostname>:<container-name>:<exposed-port>[:udp if udp]
+    <hostname>:<container-name>:<exposed-port>[:udp if udp][:tag if tagged]
 
-This is mostly an implementation detail — you typically use service names, not
-IDs.
+When an `--ip` tag is set, it is appended to the ID (e.g.,
+`host:myapp:8080:physical`). This is mostly an implementation detail — you
+typically use service names, not IDs.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -337,10 +337,10 @@ Common check options:
 
 The service ID is a cluster-wide unique identifier generated automatically:
 
-    <hostname>:<container-name>:<exposed-port>[:udp if udp][:tag if tagged]
+    <hostname>:<container-name>:<exposed-port>[:udp if udp][:alias if alias][@tag if tagged]
 
 When an `--ip` tag is set, it is appended to the ID (e.g.,
-`host:myapp:8080:physical`). This is mostly an implementation detail — you
+`host:myapp:8080@physical`). This is mostly an implementation detail — you
 typically use service names, not IDs.
 
 ### Docker

--- a/serviceregistrator/__init__.py
+++ b/serviceregistrator/__init__.py
@@ -20,13 +20,18 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from collections import UserDict
-from typing import Any
+from typing import Any, NamedTuple
 import logging
 import signal
 import sys
 
 
 log = logging.getLogger("serviceregistrator")
+
+
+class ServiceIP(NamedTuple):
+    ip: str
+    tag: str | None = None
 
 
 class ContainerMetadata(UserDict[str, Any]):

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -20,6 +20,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from collections import defaultdict
+import hashlib
 import ipaddress
 import logging
 from typing import Any
@@ -85,20 +86,24 @@ class ContainerInfo:
             return self.service_prefix + self.SERVICE_PREFIX_NAME_SEPARATOR + name
         return name
 
-    def names_count(self) -> dict[str | None, int]:
-        """Count services with same name or no name"""
-        names_count: dict[str | None, int] = defaultdict(lambda: 0)
+    def unique_ports_count(self) -> dict[str | None, int]:
+        """Count services with same name, ignoring IP differences.
+
+        Two ports that differ only by IP (same internal, external, protocol)
+        are counted once — they represent the same service on multiple IPs.
+        """
+        seen: dict[str | None, set[tuple[int, str]]] = defaultdict(set)
         for port in self.ports:
             name = self.get_name(port)
             if name:
-                names_count[name] += 1
-        return names_count
+                seen[name].add((port.external, port.protocol))
+        return {name: len(ports) for name, ports in seen.items()}
 
     def build_service_name(self, port: Any) -> str | None:
         if self._names_count is None:
-            self._names_count = self.names_count()
+            self._names_count = self.unique_ports_count()
         name = self.get_name(port)
-        count = self._names_count[name]
+        count = self._names_count.get(name, 0)
         if count < 1:
             return None
         elif count > 1:
@@ -118,13 +123,28 @@ class ContainerInfo:
     def build_service_attrs(self, port: Any) -> dict[str, str]:
         return self.get_attr("attrs", port.internal) or {}
 
-    def build_service_id(self, port: Any) -> str:
+    @staticmethod
+    def _ip_hash(ip: str) -> str:
+        """Return a short hash of an IP address for use in service IDs."""
+        return hashlib.sha256(ip.encode()).hexdigest()[:8]
+
+    def _has_multiple_ips(self, port: Any) -> bool:
+        """Check if this (external port, protocol) is bound to multiple IPs."""
+        count = sum(
+            1 for p in self.ports
+            if p.external == port.external and p.protocol == port.protocol and p.ip != port.ip
+        )
+        return count > 0
+
+    def build_service_id(self, port: Any, ip: str) -> str:
         parts: list[str] = []
         if self.service_prefix:
             parts.append(self.service_prefix)
         parts.extend([self.hostname, self.name, str(port.external)])
         if port.protocol != "tcp":
             parts.append(str(port.protocol))
+        if self._has_multiple_ips(port):
+            parts.append(self._ip_hash(ip))
         return self.SERVICE_ID_SEPARATOR.join(parts)
 
     @staticmethod
@@ -164,28 +184,30 @@ class ContainerInfo:
                 if service_name is None:
                     log.info(f"Skipping port {port}, no service name set")
                     continue
-                if service_name in services:
-                    log.warning(f"Service name already exists: {service_name} ({self})")
+                ip = self.build_service_ip(port)
+                service_id = self.build_service_id(port, ip)
+                if service_id in services:
+                    log.warning(f"Service ID already exists: {service_id} ({self})")
                     continue
                 service = Service(
                     self.cid,
-                    self.build_service_id(port),
+                    service_id,
                     service_name,
-                    self.build_service_ip(port),
+                    ip,
                     port.external,
                     tags=self.build_service_tags(port),
                     attrs=self.build_service_attrs(port),
                 )
-                services[service_name] = service
+                services[service_id] = service
 
                 # Create alias service if SERVICE_<port>_ALIAS is set
                 alias_name = self.build_service_alias(port)
                 if alias_name:
-                    alias_id = self.build_service_id(port) + self.SERVICE_ID_SEPARATOR + "alias"
-                    if alias_name in services:
-                        log.warning(f"Alias name already exists: {alias_name} ({self})")
+                    alias_id = service_id + self.SERVICE_ID_SEPARATOR + "alias"
+                    if alias_id in services:
+                        log.warning(f"Alias ID already exists: {alias_id} ({self})")
                     else:
-                        services[alias_name] = Service(
+                        services[alias_id] = Service(
                             self.cid,
                             alias_id,
                             alias_name,

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -155,9 +155,11 @@ class ContainerInfo:
         parts.extend([self.hostname, self.name, str(port.external)])
         if port.protocol != "tcp":
             parts.append(str(port.protocol))
-        if self._has_multiple_ips(port):
-            tag = self.ip_tag_map.get(ip)
-            parts.append(tag if tag else self._ip_hash(ip))
+        tag = self.ip_tag_map.get(ip)
+        if tag:
+            parts.append(tag)
+        elif self._has_multiple_ips(port):
+            parts.append(self._ip_hash(ip))
         return self.SERVICE_ID_SEPARATOR.join(parts)
 
     @staticmethod

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -25,6 +25,7 @@ import ipaddress
 import logging
 from typing import Any
 
+from serviceregistrator import ServiceIP
 from serviceregistrator.service import Service
 
 
@@ -43,7 +44,7 @@ class ContainerInfo:
         metadata: Any,
         metadata_with_port: dict[int, Any],
         hostname: str,
-        service_ips: list[tuple[str, str | None]],
+        service_ips: list[ServiceIP],
         tags: list[str],
     ) -> None:
         self.cid = cid
@@ -52,7 +53,7 @@ class ContainerInfo:
         self.metadata_with_port = metadata_with_port
         self.hostname = hostname
         self.service_ips = service_ips
-        self.ip_tag_map: dict[str, str] = {ip: tag for ip, tag in service_ips if tag}
+        self.ip_tag_map: dict[str, str] = {sip.ip: sip.tag for sip in service_ips if sip.tag}
         self.service_prefix: str | None = None
         self.tags = [x for x in set(tags) if x]
         self.health: str | None = None
@@ -61,8 +62,8 @@ class ContainerInfo:
         self.ports: list[Any] = []
         for port in ports:
             if port.ip in {"0.0.0.0", "::", ""}:
-                for ip, _tag in service_ips:
-                    self.ports.append(port._replace(ip=ip))
+                for sip in service_ips:
+                    self.ports.append(port._replace(ip=sip.ip))
             else:
                 self.ports.append(port)
 

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -156,7 +156,8 @@ class ContainerInfo:
         if port.protocol != "tcp":
             parts.append(str(port.protocol))
         if self._has_multiple_ips(port):
-            parts.append(self._ip_hash(ip))
+            tag = self.ip_tag_map.get(ip)
+            parts.append(tag if tag else self._ip_hash(ip))
         return self.SERVICE_ID_SEPARATOR.join(parts)
 
     @staticmethod

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -43,19 +43,28 @@ class ContainerInfo:
         metadata: Any,
         metadata_with_port: dict[int, Any],
         hostname: str,
-        serviceip: str,
+        service_ips: list[tuple[str, str | None]],
         tags: list[str],
     ) -> None:
         self.cid = cid
         self.name = name
-        self.ports = ports
         self.metadata = metadata
         self.metadata_with_port = metadata_with_port
         self.hostname = hostname
-        self.serviceip = serviceip
+        self.service_ips = service_ips
+        self.ip_tag_map: dict[str, str] = {ip: tag for ip, tag in service_ips if tag}
         self.service_prefix: str | None = None
         self.tags = [x for x in set(tags) if x]
         self.health: str | None = None
+
+        # Expand wildcard bindings (0.0.0.0, ::, "") into one port per --ip
+        self.ports: list[Any] = []
+        for port in ports:
+            if port.ip in {"0.0.0.0", "::", ""}:
+                for ip, _tag in service_ips:
+                    self.ports.append(port._replace(ip=ip))
+            else:
+                self.ports.append(port)
 
         self._services: list[Service] | None = None
         self._names_count: dict[str | None, int] | None = None
@@ -66,7 +75,7 @@ class ContainerInfo:
     def __repr__(self) -> str:
         return (
             "{t}('{s.cid}', '{s.name}', {s.ports}, {s.metadata}, {s.metadata_with_port}, "
-            "'{s.hostname}', '{s.serviceip}', {s.tags})"
+            "'{s.hostname}', {s.service_ips}, {s.tags})"
         ).format(t=type(self).__name__, s=self)
 
     def __bool__(self) -> bool:
@@ -112,12 +121,15 @@ class ContainerInfo:
                 name = f"{name}-{port.protocol}"
         return name
 
-    def build_service_tags(self, port: Any) -> list[str]:
+    def build_service_tags(self, port: Any, ip: str) -> list[str]:
         tags = list(self.get_attr("tags", port.internal) or [])
         if self.tags:
             tags.extend(self.tags)
         if port.protocol != "tcp":
             tags.append(port.protocol)
+        ip_tag = self.ip_tag_map.get(ip)
+        if ip_tag:
+            tags.append(ip_tag)
         return [x for x in set(tags) if x]
 
     def build_service_attrs(self, port: Any) -> dict[str, str]:
@@ -159,15 +171,12 @@ class ContainerInfo:
     def build_service_ip(self, port: Any) -> str:
         ip = self.get_attr("ip", port.internal)
         if ip is None:
-            if port.ip not in {"0.0.0.0", "::", ""}:
-                return port.ip
-            else:
-                return self.serviceip
+            return port.ip
         elif self._validate_ip(ip):
             return ip
         else:
             log.warning(f"Invalid SERVICE_IP '{ip}' for {self}, using default")
-            return self.serviceip
+            return self.service_ips[0][0]
 
     def build_service_alias(self, port: Any) -> str | None:
         attrs = self.build_service_attrs(port)
@@ -195,7 +204,7 @@ class ContainerInfo:
                     service_name,
                     ip,
                     port.external,
-                    tags=self.build_service_tags(port),
+                    tags=self.build_service_tags(port, ip),
                     attrs=self.build_service_attrs(port),
                 )
                 services[service_id] = service

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -144,8 +144,7 @@ class ContainerInfo:
     def _has_multiple_ips(self, port: Any) -> bool:
         """Check if this (external port, protocol) is bound to multiple IPs."""
         count = sum(
-            1 for p in self.ports
-            if p.external == port.external and p.protocol == port.protocol and p.ip != port.ip
+            1 for p in self.ports if p.external == port.external and p.protocol == port.protocol and p.ip != port.ip
         )
         return count > 0
 

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -148,6 +148,8 @@ class ContainerInfo:
         )
         return count > 0
 
+    SERVICE_ID_TAG_SEPARATOR = "@"
+
     def build_service_id(self, port: Any, ip: str) -> str:
         parts: list[str] = []
         if self.service_prefix:
@@ -155,12 +157,13 @@ class ContainerInfo:
         parts.extend([self.hostname, self.name, str(port.external)])
         if port.protocol != "tcp":
             parts.append(str(port.protocol))
+        base = self.SERVICE_ID_SEPARATOR.join(parts)
         tag = self.ip_tag_map.get(ip)
         if tag:
-            parts.append(tag)
+            return base + self.SERVICE_ID_TAG_SEPARATOR + tag
         elif self._has_multiple_ips(port):
-            parts.append(self._ip_hash(ip))
-        return self.SERVICE_ID_SEPARATOR.join(parts)
+            return base + self.SERVICE_ID_TAG_SEPARATOR + self._ip_hash(ip)
+        return base
 
     @staticmethod
     def _validate_ip(ip: str) -> bool:
@@ -215,7 +218,12 @@ class ContainerInfo:
                 # Create alias service if SERVICE_<port>_ALIAS is set
                 alias_name = self.build_service_alias(port)
                 if alias_name:
-                    alias_id = service_id + self.SERVICE_ID_SEPARATOR + "alias"
+                    # Insert :alias before @tag so is_our_identifier can parse both
+                    if self.SERVICE_ID_TAG_SEPARATOR in service_id:
+                        base, tag_part = service_id.split(self.SERVICE_ID_TAG_SEPARATOR, 1)
+                        alias_id = base + self.SERVICE_ID_SEPARATOR + "alias" + self.SERVICE_ID_TAG_SEPARATOR + tag_part
+                    else:
+                        alias_id = service_id + self.SERVICE_ID_SEPARATOR + "alias"
                     if alias_id in services:
                         log.warning(f"Alias ID already exists: {alias_id} ({self})")
                     else:

--- a/serviceregistrator/main.py
+++ b/serviceregistrator/main.py
@@ -28,6 +28,7 @@ import traceback
 from time import sleep
 
 from serviceregistrator import Context
+from serviceregistrator import ServiceIP
 from serviceregistrator.registrator import ServiceRegistrator, ConsulConnectionError
 
 
@@ -61,7 +62,7 @@ def parse_ip_tags(ctx, param, value):
             ipaddress.ip_address(ip)
         except ValueError:
             raise click.BadParameter(f"invalid IP address: {ip}")
-        result.append((ip, tag))
+        result.append(ServiceIP(ip, tag))
     if not result:
         raise click.BadParameter("at least one --ip is required")
     return result

--- a/serviceregistrator/main.py
+++ b/serviceregistrator/main.py
@@ -78,7 +78,14 @@ POSSIBLE_LEVELS = (
 
 
 @click.command()
-@click.option("-i", "--ip", help="address for services (IP or IP@TAG, repeatable)", required=True, multiple=True, callback=parse_ip_tags)
+@click.option(
+    "-i",
+    "--ip",
+    help="address for services (IP or IP@TAG, repeatable)",
+    required=True,
+    multiple=True,
+    callback=parse_ip_tags,
+)
 @click.option("-t", "--tags", help="comma-separated list of tags to append to all registered services", default="")
 @click.option("-h", "--consul-host", help="consul agent host", default="127.0.0.1", show_default=True)
 @click.option("-p", "--consul-port", help="consul agent port", default=8500, type=click.INT, show_default=True)

--- a/serviceregistrator/main.py
+++ b/serviceregistrator/main.py
@@ -47,6 +47,26 @@ def validate_ip(ctx, param, value):
     return value
 
 
+def parse_ip_tags(ctx, param, value):
+    """Parse multiple --ip values in IP or IP@TAG format."""
+    result = []
+    for entry in value:
+        if "@" in entry:
+            ip, tag = entry.rsplit("@", 1)
+            if not tag:
+                raise click.BadParameter(f"empty tag in: {entry}")
+        else:
+            ip, tag = entry, None
+        try:
+            ipaddress.ip_address(ip)
+        except ValueError:
+            raise click.BadParameter(f"invalid IP address: {ip}")
+        result.append((ip, tag))
+    if not result:
+        raise click.BadParameter("at least one --ip is required")
+    return result
+
+
 POSSIBLE_LEVELS = (
     "CRITICAL",
     "ERROR",
@@ -57,7 +77,7 @@ POSSIBLE_LEVELS = (
 
 
 @click.command()
-@click.option("-i", "--ip", help="address to use for services without SERVICE_IP", required=True, callback=validate_ip)
+@click.option("-i", "--ip", help="address for services (IP or IP@TAG, repeatable)", required=True, multiple=True, callback=parse_ip_tags)
 @click.option("-t", "--tags", help="comma-separated list of tags to append to all registered services", default="")
 @click.option("-h", "--consul-host", help="consul agent host", default="127.0.0.1", show_default=True)
 @click.option("-p", "--consul-port", help="consul agent port", default=8500, type=click.INT, show_default=True)

--- a/serviceregistrator/registrator.py
+++ b/serviceregistrator/registrator.py
@@ -513,7 +513,9 @@ class ServiceRegistrator:
             log.debug(f"no registered container {container_info}")
 
     def is_our_identifier(self, serviceid: str, prefix: str = "") -> tuple[bool, str | None]:
-        identifier = serviceid.split(":")
+        # Strip @tag suffix (IP tag or hash) before parsing
+        base = serviceid.split("@")[0]
+        identifier = base.split(":")
         length = len(identifier)
         if prefix:
             if identifier[0] != prefix:
@@ -525,10 +527,6 @@ class ServiceRegistrator:
             return False, "length < 3"
         # Strip known suffixes: :udp, :alias
         while length > 3 and identifier[-1] in ("udp", "alias"):
-            identifier = identifier[:-1]
-            length -= 1
-        # Strip one optional IP tag or hash suffix
-        if length == 4:
             identifier = identifier[:-1]
             length -= 1
         if length > 3:

--- a/serviceregistrator/registrator.py
+++ b/serviceregistrator/registrator.py
@@ -512,6 +512,11 @@ class ServiceRegistrator:
         else:
             log.debug(f"no registered container {container_info}")
 
+    @staticmethod
+    def _is_ip_hash(s: str) -> bool:
+        """Check if a string looks like an 8-char hex IP hash."""
+        return len(s) == 8 and all(c in "0123456789abcdef" for c in s)
+
     def is_our_identifier(self, serviceid: str, prefix: str = "") -> tuple[bool, str | None]:
         identifier = serviceid.split(":")
         length = len(identifier)
@@ -523,8 +528,11 @@ class ServiceRegistrator:
                 length -= 1
         if length < 3:
             return False, "length < 3"
-        # Strip known suffixes: :udp, :alias
+        # Strip known suffixes: :udp, :alias, :iphash
         while length > 3 and identifier[-1] in ("udp", "alias"):
+            identifier = identifier[:-1]
+            length -= 1
+        if length > 3 and self._is_ip_hash(identifier[-1]):
             identifier = identifier[:-1]
             length -= 1
         if length > 3:

--- a/serviceregistrator/registrator.py
+++ b/serviceregistrator/registrator.py
@@ -512,11 +512,6 @@ class ServiceRegistrator:
         else:
             log.debug(f"no registered container {container_info}")
 
-    @staticmethod
-    def _is_ip_hash(s: str) -> bool:
-        """Check if a string looks like an 8-char hex IP hash."""
-        return len(s) == 8 and all(c in "0123456789abcdef" for c in s)
-
     def is_our_identifier(self, serviceid: str, prefix: str = "") -> tuple[bool, str | None]:
         identifier = serviceid.split(":")
         length = len(identifier)
@@ -528,11 +523,12 @@ class ServiceRegistrator:
                 length -= 1
         if length < 3:
             return False, "length < 3"
-        # Strip known suffixes: :udp, :alias, :iphash
+        # Strip known suffixes: :udp, :alias
         while length > 3 and identifier[-1] in ("udp", "alias"):
             identifier = identifier[:-1]
             length -= 1
-        if length > 3 and self._is_ip_hash(identifier[-1]):
+        # Strip one optional IP tag or hash suffix
+        if length == 4:
             identifier = identifier[:-1]
             length -= 1
         if length > 3:

--- a/testing/dummyservice/run_all.sh
+++ b/testing/dummyservice/run_all.sh
@@ -79,7 +79,7 @@ done
 
 echo "=== Starting serviceregistrator ==="
 cd "$PROJECT_DIR"
-uv run serviceregistrator --ip 127.0.0.1 --loglevel DEBUG > "$LOG" 2>&1 &
+uv run serviceregistrator --ip 127.0.0.1@physical --ip 127.0.0.2@virtual --loglevel DEBUG > "$LOG" 2>&1 &
 SR_PID=$!
 sleep 2
 
@@ -210,17 +210,24 @@ check "Dual-IP: 127.0.0.1 registered" sh -c "echo '$DUALIP_IPS' | grep -q '127.0
 check "Dual-IP: 127.0.0.2 registered" sh -c "echo '$DUALIP_IPS' | grep -q '127.0.0.2'"
 
 echo ""
-echo "=== Test: all-interfaces binding (0.0.0.0, uses --ip default) ==="
+echo "=== Test: all-interfaces binding expands to multiple IPs with tags ==="
 docker rm -f dummyservice_allif 2>/dev/null || true
 docker run -d --name dummyservice_allif \
     --env "SERVICE_80_NAME=dummyservice_allif" \
     --publish "8091:80" \
     dummyservice >/dev/null
-wait_for_log "REGISTER.*dummyservice_allif"
+wait_for_log "REGISTER.*dummyservice_allif" 10
+sleep 2
 SERVICES=$(curl -sf http://127.0.0.1:$CONSUL_PORT/v1/agent/services)
-ALLIF_IP=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(next((v['Address'] for v in d.values() if 'dummyservice_allif' in v.get('Service','')), 'none'))")
-echo "  INFO: all-interfaces container registered with IP: $ALLIF_IP"
-check "All-interfaces: uses --ip default (127.0.0.1)" sh -c "[ '$ALLIF_IP' = '127.0.0.1' ]"
+ALLIF_COUNT=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for v in d.values() if v.get('Service','') == 'dummyservice_allif'))")
+echo "  INFO: registered $ALLIF_COUNT service(s) for all-interfaces container"
+ALLIF_IPS=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join(sorted(v['Address'] for v in d.values() if v.get('Service','') == 'dummyservice_allif')))")
+echo "  INFO: registered IPs: $ALLIF_IPS"
+ALLIF_TAGS=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); tags=[t for v in d.values() if v.get('Service','') == 'dummyservice_allif' for t in v.get('Tags',[])]; print(' '.join(sorted(set(tags))))")
+echo "  INFO: tags: $ALLIF_TAGS"
+check "All-interfaces: both IPs registered" sh -c "[ $ALLIF_COUNT -eq 2 ]"
+check "All-interfaces: physical tag present" sh -c "echo '$ALLIF_TAGS' | grep -q 'physical'"
+check "All-interfaces: virtual tag present" sh -c "echo '$ALLIF_TAGS' | grep -q 'virtual'"
 
 echo ""
 echo "=== Test: container removal triggers unregister ==="

--- a/testing/dummyservice/run_all.sh
+++ b/testing/dummyservice/run_all.sh
@@ -16,7 +16,8 @@ cleanup() {
              dummyservice_checktcp dummyservice_checkhttp \
              dummyservice_checkscript dummyservice_checkscript2 \
              dummyservice_checkdocker dummyservice_alias \
-             dummyservice_unhealthy dev-consul; do
+             dummyservice_unhealthy dummyservice_dualip \
+             dummyservice_allif dev-consul; do
         docker rm -f "$c" 2>/dev/null || true
     done
     rm -f "$LOG"
@@ -184,6 +185,44 @@ echo "=== Test: health transition (unhealthy -> healthy) ==="
 docker exec dummyservice_unhealthy mv -f /www/index.html.bak /www/index.html
 wait_for_log "REGISTER CONTAINER.*dummyservice_unhealthy" 30
 check_log "Container registered after becoming healthy" "REGISTER CONTAINER.*dummyservice_unhealthy"
+
+echo ""
+echo "=== Test: dual-IP binding (same port on two IPs) ==="
+docker rm -f dummyservice_dualip 2>/dev/null || true
+docker run -d --name dummyservice_dualip \
+    --env "SERVICE_80_NAME=dummyservice_dualip" \
+    --env "SERVICE_80_CHECK_TCP=true" \
+    --env "SERVICE_80_CHECK_INTERVAL=10s" \
+    --publish "127.0.0.1:8090:80" \
+    --publish "127.0.0.2:8090:80" \
+    dummyservice >/dev/null
+wait_for_log "REGISTER CONTAINER.*dummyservice_dualip" 40
+sleep 2
+SERVICES=$(curl -sf http://127.0.0.1:$CONSUL_PORT/v1/agent/services)
+# Count how many services were registered for this container
+DUALIP_COUNT=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for v in d.values() if 'dummyservice_dualip' in v.get('Service','')))")
+echo "  INFO: registered $DUALIP_COUNT service(s) for dual-IP container"
+check "Dual-IP: at least one service registered" sh -c "[ $DUALIP_COUNT -ge 1 ]"
+# Check what IPs were registered
+DUALIP_IPS=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join(sorted(v['Address'] for v in d.values() if 'dummyservice_dualip' in v.get('Service',''))))")
+echo "  INFO: registered IPs: $DUALIP_IPS"
+# Currently only one IP gets registered (the second is dropped as duplicate name).
+# With multi-IP support, both should be registered:
+# check "Dual-IP: both IPs registered" sh -c "[ $DUALIP_COUNT -eq 2 ]"
+check_log "Dual-IP: second IP dropped as duplicate" "Service name already exists: dummyservice_dualip"
+
+echo ""
+echo "=== Test: all-interfaces binding (0.0.0.0, uses --ip default) ==="
+docker rm -f dummyservice_allif 2>/dev/null || true
+docker run -d --name dummyservice_allif \
+    --env "SERVICE_80_NAME=dummyservice_allif" \
+    --publish "8091:80" \
+    dummyservice >/dev/null
+wait_for_log "REGISTER.*dummyservice_allif"
+SERVICES=$(curl -sf http://127.0.0.1:$CONSUL_PORT/v1/agent/services)
+ALLIF_IP=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(next((v['Address'] for v in d.values() if 'dummyservice_allif' in v.get('Service','')), 'none'))")
+echo "  INFO: all-interfaces container registered with IP: $ALLIF_IP"
+check "All-interfaces: uses --ip default (127.0.0.1)" sh -c "[ '$ALLIF_IP' = '127.0.0.1' ]"
 
 echo ""
 echo "=== Test: container removal triggers unregister ==="

--- a/testing/dummyservice/run_all.sh
+++ b/testing/dummyservice/run_all.sh
@@ -202,14 +202,12 @@ SERVICES=$(curl -sf http://127.0.0.1:$CONSUL_PORT/v1/agent/services)
 # Count how many services were registered for this container
 DUALIP_COUNT=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for v in d.values() if 'dummyservice_dualip' in v.get('Service','')))")
 echo "  INFO: registered $DUALIP_COUNT service(s) for dual-IP container"
-check "Dual-IP: at least one service registered" sh -c "[ $DUALIP_COUNT -ge 1 ]"
 # Check what IPs were registered
 DUALIP_IPS=$(echo "$SERVICES" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join(sorted(v['Address'] for v in d.values() if 'dummyservice_dualip' in v.get('Service',''))))")
 echo "  INFO: registered IPs: $DUALIP_IPS"
-# Currently only one IP gets registered (the second is dropped as duplicate name).
-# With multi-IP support, both should be registered:
-# check "Dual-IP: both IPs registered" sh -c "[ $DUALIP_COUNT -eq 2 ]"
-check_log "Dual-IP: second IP dropped as duplicate" "Service name already exists: dummyservice_dualip"
+check "Dual-IP: both IPs registered" sh -c "[ $DUALIP_COUNT -eq 2 ]"
+check "Dual-IP: 127.0.0.1 registered" sh -c "echo '$DUALIP_IPS' | grep -q '127.0.0.1'"
+check "Dual-IP: 127.0.0.2 registered" sh -c "echo '$DUALIP_IPS' | grep -q '127.0.0.2'"
 
 echo ""
 echo "=== Test: all-interfaces binding (0.0.0.0, uses --ip default) ==="

--- a/tests/containerinfo_extended_test.py
+++ b/tests/containerinfo_extended_test.py
@@ -100,8 +100,8 @@ class TestServicesDuplicateName(unittest.TestCase):
         assert "svc-8080" in names
         assert "svc-8081" in names
 
-    def test_duplicate_service_name_skipped(self):
-        """Force build_service_name to return same name for two ports — second is skipped."""
+    def test_duplicate_service_name_different_ids_allowed(self):
+        """Same service name on different ports with different IDs — both registered."""
 
         ci = ContainerInfo(
             "cid",
@@ -119,7 +119,10 @@ class TestServicesDuplicateName(unittest.TestCase):
         # Monkey-patch build_service_name to always return the same name
         ci.build_service_name = lambda port: "svc"
         services = ci.services
-        assert len(services) == 1
+        assert len(services) == 2
+        # Both have the same name but different IDs
+        assert services[0].name == services[1].name == "svc"
+        assert services[0].id != services[1].id
 
 
 class TestBuildServiceIpValidation(unittest.TestCase):
@@ -211,7 +214,7 @@ class TestBuildServiceAlias(unittest.TestCase):
         assert "db" in alias.tags
 
     def test_alias_name_collision_with_service_name(self):
-        """Alias name same as another service name — alias is skipped."""
+        """Alias name same as service name — both registered (different IDs)."""
         ci = ContainerInfo(
             "cid",
             "name",
@@ -223,6 +226,9 @@ class TestBuildServiceAlias(unittest.TestCase):
             [],
         )
         services = ci.services
-        assert len(services) == 1
-        assert services[0].name == "real-svc"
-        assert services[0].alias_of is None
+        assert len(services) == 2
+        real = [s for s in services if s.alias_of is None][0]
+        alias = [s for s in services if s.alias_of is not None][0]
+        assert real.name == "real-svc"
+        assert alias.name == "real-svc"
+        assert alias.id.endswith(":alias")

--- a/tests/containerinfo_extended_test.py
+++ b/tests/containerinfo_extended_test.py
@@ -13,7 +13,7 @@ class TestContainerInfoStringRepresentations(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "myhost",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
 
@@ -40,14 +40,14 @@ class TestBuildServiceIpPortSpecific(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
-        port = Ports(internal=80, external=8080, protocol="tcp", ip="10.0.0.5")
-        ip = ci.build_service_ip(port)
+        ip = ci.build_service_ip(ci.ports[0])
         assert ip == "10.0.0.5"
 
     def test_port_ip_ipv6_wildcard(self):
+        """Wildcard :: is expanded to the default --ip."""
         ci = ContainerInfo(
             "cid",
             "name",
@@ -55,14 +55,14 @@ class TestBuildServiceIpPortSpecific(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
-        port = Ports(internal=80, external=8080, protocol="tcp", ip="::")
-        ip = ci.build_service_ip(port)
+        ip = ci.build_service_ip(ci.ports[0])
         assert ip == "127.0.0.1"
 
     def test_port_ip_empty(self):
+        """Empty IP is expanded to the default --ip."""
         ci = ContainerInfo(
             "cid",
             "name",
@@ -70,11 +70,10 @@ class TestBuildServiceIpPortSpecific(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
-        port = Ports(internal=80, external=8080, protocol="tcp", ip="")
-        ip = ci.build_service_ip(port)
+        ip = ci.build_service_ip(ci.ports[0])
         assert ip == "127.0.0.1"
 
 
@@ -91,7 +90,7 @@ class TestServicesDuplicateName(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "svc"})},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
         services = ci.services
@@ -113,7 +112,7 @@ class TestServicesDuplicateName(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
         # Monkey-patch build_service_name to always return the same name
@@ -134,28 +133,28 @@ class TestBuildServiceIpValidation(unittest.TestCase):
             ContainerMetadata({"name": "svc", "ip": service_ip_override}),
             {},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
 
     def test_valid_ipv4(self):
         ci = self._make_ci("10.0.0.1")
-        ip = ci.build_service_ip(Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0"))
+        ip = ci.build_service_ip(ci.ports[0])
         assert ip == "10.0.0.1"
 
     def test_valid_ipv6(self):
         ci = self._make_ci("::1")
-        ip = ci.build_service_ip(Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0"))
+        ip = ci.build_service_ip(ci.ports[0])
         assert ip == "::1"
 
     def test_invalid_ip_shell_injection(self):
         ci = self._make_ci("$(whoami)")
-        ip = ci.build_service_ip(Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0"))
+        ip = ci.build_service_ip(ci.ports[0])
         assert ip == "127.0.0.1"  # falls back to default
 
     def test_invalid_ip_arbitrary_string(self):
         ci = self._make_ci("not-an-ip; rm -rf /")
-        ip = ci.build_service_ip(Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0"))
+        ip = ci.build_service_ip(ci.ports[0])
         assert ip == "127.0.0.1"
 
 
@@ -168,7 +167,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc", "alias": "alias-svc"})},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
         services = ci.services
@@ -191,7 +190,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc"})},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
         services = ci.services
@@ -206,7 +205,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc", "alias": "alias-svc", "tags": "prod,db"})},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
         alias = [s for s in ci.services if s.name == "alias-svc"][0]
@@ -222,7 +221,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc", "alias": "real-svc"})},
             "host",
-            "127.0.0.1",
+            [("127.0.0.1", None)],
             [],
         )
         services = ci.services

--- a/tests/containerinfo_extended_test.py
+++ b/tests/containerinfo_extended_test.py
@@ -1,5 +1,5 @@
 import unittest
-from serviceregistrator import ContainerMetadata
+from serviceregistrator import ContainerMetadata, ServiceIP
 from serviceregistrator.containerinfo import ContainerInfo
 from serviceregistrator.registrator import Ports
 
@@ -13,7 +13,7 @@ class TestContainerInfoStringRepresentations(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "myhost",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
 
@@ -40,7 +40,7 @@ class TestBuildServiceIpPortSpecific(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         ip = ci.build_service_ip(ci.ports[0])
@@ -55,7 +55,7 @@ class TestBuildServiceIpPortSpecific(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         ip = ci.build_service_ip(ci.ports[0])
@@ -70,7 +70,7 @@ class TestBuildServiceIpPortSpecific(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         ip = ci.build_service_ip(ci.ports[0])
@@ -90,7 +90,7 @@ class TestServicesDuplicateName(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "svc"})},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         services = ci.services
@@ -112,7 +112,7 @@ class TestServicesDuplicateName(unittest.TestCase):
             ContainerMetadata({"name": "svc"}),
             {},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         # Monkey-patch build_service_name to always return the same name
@@ -133,7 +133,7 @@ class TestBuildServiceIpValidation(unittest.TestCase):
             ContainerMetadata({"name": "svc", "ip": service_ip_override}),
             {},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
 
@@ -167,7 +167,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc", "alias": "alias-svc"})},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         services = ci.services
@@ -190,7 +190,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc"})},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         services = ci.services
@@ -205,7 +205,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc", "alias": "alias-svc", "tags": "prod,db"})},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         alias = [s for s in ci.services if s.name == "alias-svc"][0]
@@ -221,7 +221,7 @@ class TestBuildServiceAlias(unittest.TestCase):
             ContainerMetadata(),
             {80: ContainerMetadata({"name": "real-svc", "alias": "real-svc"})},
             "host",
-            [("127.0.0.1", None)],
+            [ServiceIP("127.0.0.1")],
             [],
         )
         services = ci.services

--- a/tests/containerinfo_test.py
+++ b/tests/containerinfo_test.py
@@ -81,14 +81,14 @@ class TestContainerInfo(unittest.TestCase):
         self.assertIsNone(value)
 
     def test_names_count(self):
-        counts = self.container_info.names_count()
+        counts = self.container_info.unique_ports_count()
         self.assertIn("dummyservice_80_name", counts)
         self.assertEqual(counts["dummyservice_80_name"], 1)
 
     def test_names_count_no_name(self):
         self.container_info.metadata = ContainerMetadata()
         self.container_info.ports = [Ports(internal=81, external=8086, protocol="tcp", ip="0.0.0.0")]
-        counts = self.container_info.names_count()
+        counts = self.container_info.unique_ports_count()
         self.assertNotIn("dummyservice_80_name", counts)
         self.assertEqual(counts, {})
 
@@ -103,7 +103,7 @@ class TestContainerInfo(unittest.TestCase):
             Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0"),
             Ports(internal=81, external=8087, protocol="tcp", ip="0.0.0.0"),
         ]
-        counts = self.container_info.names_count()
+        counts = self.container_info.unique_ports_count()
         self.assertIn("dummyservice_80_name", counts)
         self.assertIn("dummyservice_81_name", counts)
         self.assertEqual(counts["dummyservice_80_name"], 1)
@@ -116,7 +116,7 @@ class TestContainerInfo(unittest.TestCase):
             Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0"),
             Ports(internal=81, external=8087, protocol="tcp", ip="0.0.0.0"),
         ]
-        counts = self.container_info.names_count()
+        counts = self.container_info.unique_ports_count()
         self.assertIn("dummyservice_name", counts)
         self.assertEqual(counts["dummyservice_name"], 2)
 
@@ -189,7 +189,7 @@ class TestContainerInfo(unittest.TestCase):
 
     def test_build_service_id(self):
         port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port)
+        service_id = self.container_info.build_service_id(port, "127.6.6.6")
         self.assertEqual(
             service_id, self.container_info.SERVICE_ID_SEPARATOR.join(("my_host_name", "dummyservice", "8086"))
         )
@@ -197,7 +197,7 @@ class TestContainerInfo(unittest.TestCase):
     def test_build_service_id_prefix(self):
         self.container_info.service_prefix = "x"
         port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port)
+        service_id = self.container_info.build_service_id(port, "127.6.6.6")
         self.assertEqual(
             service_id,
             self.container_info.SERVICE_ID_SEPARATOR.join(
@@ -207,7 +207,7 @@ class TestContainerInfo(unittest.TestCase):
 
     def test_build_service_id_udp(self):
         port = Ports(internal=80, external=8086, protocol="udp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port)
+        service_id = self.container_info.build_service_id(port, "127.6.6.6")
         self.assertEqual(
             service_id, self.container_info.SERVICE_ID_SEPARATOR.join(("my_host_name", "dummyservice", "8086", "udp"))
         )
@@ -215,7 +215,7 @@ class TestContainerInfo(unittest.TestCase):
     def test_build_service_id_udp_prefix(self):
         self.container_info.service_prefix = "x"
         port = Ports(internal=80, external=8086, protocol="udp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port)
+        service_id = self.container_info.build_service_id(port, "127.6.6.6")
         self.assertEqual(
             service_id,
             self.container_info.SERVICE_ID_SEPARATOR.join(

--- a/tests/containerinfo_test.py
+++ b/tests/containerinfo_test.py
@@ -1,5 +1,5 @@
 import unittest
-from serviceregistrator import ContainerMetadata
+from serviceregistrator import ContainerMetadata, ServiceIP
 from serviceregistrator.containerinfo import ContainerInfo
 from serviceregistrator.registrator import Ports
 
@@ -12,7 +12,7 @@ class TestContainerInfo(unittest.TestCase):
         container_id = "deadbeef"
         service_name = "dummyservice"
         hostname = "my_host_name"
-        ip = [("127.6.6.6", None)]
+        ip = [ServiceIP("127.6.6.6")]
         tags = ["tag1", "tag2"]
         self.container_info = ContainerInfo(
             container_id, service_name, ports, metadata, metadata_with_port, hostname, ip, tags

--- a/tests/containerinfo_test.py
+++ b/tests/containerinfo_test.py
@@ -12,7 +12,7 @@ class TestContainerInfo(unittest.TestCase):
         container_id = "deadbeef"
         service_name = "dummyservice"
         hostname = "my_host_name"
-        ip = "127.6.6.6"
+        ip = [("127.6.6.6", None)]
         tags = ["tag1", "tag2"]
         self.container_info = ContainerInfo(
             container_id, service_name, ports, metadata, metadata_with_port, hostname, ip, tags
@@ -155,25 +155,25 @@ class TestContainerInfo(unittest.TestCase):
 
     def test_services_tags(self):
         port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        tags = self.container_info.build_service_tags(port)
+        tags = self.container_info.build_service_tags(port, "127.6.6.6")
         self.assertEqual(set(tags), set(["tag2", "tag1"]))
 
     def test_services_tags_metadata(self):
         self.container_info.metadata = ContainerMetadata({"tags": "tag3,tag4"})
         port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        tags = self.container_info.build_service_tags(port)
+        tags = self.container_info.build_service_tags(port, "127.6.6.6")
         self.assertEqual(set(tags), set(["tag4", "tag3", "tag2", "tag1"]))
 
     def test_services_tags_metadata_notags(self):
         self.container_info.tags = []
         self.container_info.metadata = ContainerMetadata({"tags": "tag3,tag4"})
         port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        tags = self.container_info.build_service_tags(port)
+        tags = self.container_info.build_service_tags(port, "127.6.6.6")
         self.assertEqual(set(tags), set(["tag4", "tag3"]))
 
     def test_services_tags_udp(self):
         port = Ports(internal=80, external=8086, protocol="udp", ip="0.0.0.0")
-        tags = self.container_info.build_service_tags(port)
+        tags = self.container_info.build_service_tags(port, "127.6.6.6")
         self.assertEqual(set(tags), set(["tag2", "tag1", "udp"]))
 
     def test_build_service_attrs(self):
@@ -188,16 +188,14 @@ class TestContainerInfo(unittest.TestCase):
         self.assertEqual(attrs, {"k": "v"})
 
     def test_build_service_id(self):
-        port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port, "127.6.6.6")
+        service_id = self.container_info.build_service_id(self.container_info.ports[0], "127.6.6.6")
         self.assertEqual(
             service_id, self.container_info.SERVICE_ID_SEPARATOR.join(("my_host_name", "dummyservice", "8086"))
         )
 
     def test_build_service_id_prefix(self):
         self.container_info.service_prefix = "x"
-        port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port, "127.6.6.6")
+        service_id = self.container_info.build_service_id(self.container_info.ports[0], "127.6.6.6")
         self.assertEqual(
             service_id,
             self.container_info.SERVICE_ID_SEPARATOR.join(
@@ -206,16 +204,16 @@ class TestContainerInfo(unittest.TestCase):
         )
 
     def test_build_service_id_udp(self):
-        port = Ports(internal=80, external=8086, protocol="udp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port, "127.6.6.6")
+        self.container_info.ports = [Ports(internal=80, external=8086, protocol="udp", ip="127.6.6.6")]
+        service_id = self.container_info.build_service_id(self.container_info.ports[0], "127.6.6.6")
         self.assertEqual(
             service_id, self.container_info.SERVICE_ID_SEPARATOR.join(("my_host_name", "dummyservice", "8086", "udp"))
         )
 
     def test_build_service_id_udp_prefix(self):
         self.container_info.service_prefix = "x"
-        port = Ports(internal=80, external=8086, protocol="udp", ip="0.0.0.0")
-        service_id = self.container_info.build_service_id(port, "127.6.6.6")
+        self.container_info.ports = [Ports(internal=80, external=8086, protocol="udp", ip="127.6.6.6")]
+        service_id = self.container_info.build_service_id(self.container_info.ports[0], "127.6.6.6")
         self.assertEqual(
             service_id,
             self.container_info.SERVICE_ID_SEPARATOR.join(
@@ -224,22 +222,17 @@ class TestContainerInfo(unittest.TestCase):
         )
 
     def test_build_service_ip(self):
-        port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        ip = self.container_info.build_service_ip(port)
+        ip = self.container_info.build_service_ip(self.container_info.ports[0])
         self.assertEqual(ip, "127.6.6.6")
 
     def test_build_service_ip_metadata(self):
         self.container_info.metadata = ContainerMetadata({"ip": "1.2.3.4"})
-
-        port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        ip = self.container_info.build_service_ip(port)
+        ip = self.container_info.build_service_ip(self.container_info.ports[0])
         self.assertEqual(ip, "1.2.3.4")
 
     def test_build_service_ip_metadata_port(self):
         self.container_info.metadata_with_port = {80: ContainerMetadata({"ip": "4.3.2.1"})}
-
-        port = Ports(internal=80, external=8086, protocol="tcp", ip="0.0.0.0")
-        ip = self.container_info.build_service_ip(port)
+        ip = self.container_info.build_service_ip(self.container_info.ports[0])
         self.assertEqual(ip, "4.3.2.1")
 
     def test_services(self):

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -13,6 +13,7 @@ import docker
 import pytest
 import requests
 
+from serviceregistrator import ServiceIP
 from serviceregistrator.consul_client import ConsulClient
 
 CONSUL_IMAGE = "hashicorp/consul:1.15"
@@ -99,7 +100,7 @@ def _make_sr(prefix, ip_tags=None):
     from serviceregistrator.registrator import ServiceRegistrator
 
     options = {
-        "ip": ip_tags or [("127.0.0.1", None)],
+        "ip": ip_tags or [ServiceIP("127.0.0.1")],
         "tags": "",
         "consul_host": "127.0.0.1",
         "consul_port": CONSUL_PORT,
@@ -377,7 +378,7 @@ class TestServiceRegistratorIntegration:
 
         host_port = int(container.ports["80/tcp"][0]["HostPort"])
 
-        sr = _make_sr(prefix, ip_tags=[("127.0.0.1", "physical"), ("127.0.0.2", "virtual")])
+        sr = _make_sr(prefix, ip_tags=[ServiceIP("127.0.0.1", "physical"), ServiceIP("127.0.0.2", "virtual")])
         sr.sync_with_containers()
 
         services = _services_with_prefix(consul, prefix)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -357,9 +357,7 @@ class TestServiceRegistratorIntegration:
         alias_svcs = {k: v for k, v in services.items() if "inttest-alias-svc" in k}
         assert len(alias_svcs) == 0
 
-
     def test_sync_multi_ip_with_tags(self, consul, docker_client, cleanup_containers):
-        hostname = socket.gethostname()
         prefix = "inttest-mip"
 
         container = docker_client.containers.run(
@@ -375,8 +373,6 @@ class TestServiceRegistratorIntegration:
         )
         cleanup_containers(container)
         container.reload()
-
-        host_port = int(container.ports["80/tcp"][0]["HostPort"])
 
         sr = _make_sr(prefix, ip_tags=[ServiceIP("127.0.0.1", "physical"), ServiceIP("127.0.0.2", "virtual")])
         sr.sync_with_containers()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -93,13 +93,13 @@ def cleanup_containers(docker_client):
             pass
 
 
-def _make_sr(prefix):
+def _make_sr(prefix, ip_tags=None):
     """Create a ServiceRegistrator with a unique prefix to isolate from host containers."""
     from serviceregistrator import Context
     from serviceregistrator.registrator import ServiceRegistrator
 
     options = {
-        "ip": [("127.0.0.1", None)],
+        "ip": ip_tags or [("127.0.0.1", None)],
         "tags": "",
         "consul_host": "127.0.0.1",
         "consul_port": CONSUL_PORT,
@@ -355,6 +355,62 @@ class TestServiceRegistratorIntegration:
         services = _services_with_prefix(consul, prefix)
         alias_svcs = {k: v for k, v in services.items() if "inttest-alias-svc" in k}
         assert len(alias_svcs) == 0
+
+
+    def test_sync_multi_ip_with_tags(self, consul, docker_client, cleanup_containers):
+        hostname = socket.gethostname()
+        prefix = "inttest-mip"
+
+        container = docker_client.containers.run(
+            NGINX_IMAGE,
+            detach=True,
+            ports={"80/tcp": None},
+            environment=[
+                "SERVICE_80_NAME=inttest-multiip",
+                "SERVICE_80_CHECK_TCP=true",
+                "SERVICE_80_CHECK_INTERVAL=10s",
+            ],
+            name="inttest-multiip-svc",
+        )
+        cleanup_containers(container)
+        container.reload()
+
+        host_port = int(container.ports["80/tcp"][0]["HostPort"])
+
+        sr = _make_sr(prefix, ip_tags=[("127.0.0.1", "physical"), ("127.0.0.2", "virtual")])
+        sr.sync_with_containers()
+
+        services = _services_with_prefix(consul, prefix)
+        mip_svcs = {k: v for k, v in services.items() if "inttest-multiip-svc" in k}
+        assert len(mip_svcs) == 2, f"Expected 2 services, got {list(mip_svcs.keys())}"
+
+        # Check IPs and tags
+        ips = {v["Address"] for v in mip_svcs.values()}
+        assert ips == {"127.0.0.1", "127.0.0.2"}
+
+        for svc_id, svc in mip_svcs.items():
+            if svc["Address"] == "127.0.0.1":
+                assert "physical" in svc["Tags"]
+                assert svc_id.endswith("@physical")
+            else:
+                assert "virtual" in svc["Tags"]
+                assert svc_id.endswith("@virtual")
+
+        # Verify each instance has its own health check
+        checks_resp = requests.get(f"http://127.0.0.1:{CONSUL_PORT}/v1/agent/checks")
+        checks = checks_resp.json()
+        mip_checks = {k: v for k, v in checks.items() if v.get("ServiceID", "") in mip_svcs}
+        assert len(mip_checks) == 2
+
+        # Cleanup
+        container.stop(timeout=1)
+        container.remove(force=True)
+        sr.containers.clear()
+        sr.sync_with_containers()
+
+        services = _services_with_prefix(consul, prefix)
+        mip_svcs = {k: v for k, v in services.items() if "inttest-multiip-svc" in k}
+        assert len(mip_svcs) == 0
 
 
 class TestMainLoopIntegration:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -99,7 +99,7 @@ def _make_sr(prefix):
     from serviceregistrator.registrator import ServiceRegistrator
 
     options = {
-        "ip": "127.0.0.1",
+        "ip": [("127.0.0.1", None)],
         "tags": "",
         "consul_host": "127.0.0.1",
         "consul_port": CONSUL_PORT,

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,6 +1,6 @@
 import unittest
 from click.testing import CliRunner
-from serviceregistrator.main import main, loglevelfmt, validate_ip
+from serviceregistrator.main import main, loglevelfmt, validate_ip, parse_ip_tags
 
 
 class TestLogLevelFmt(unittest.TestCase):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,6 +1,6 @@
 import unittest
 from click.testing import CliRunner
-from serviceregistrator.main import main, loglevelfmt, validate_ip, parse_ip_tags
+from serviceregistrator.main import main, loglevelfmt, validate_ip
 
 
 class TestLogLevelFmt(unittest.TestCase):

--- a/tests/registrator_extended_test.py
+++ b/tests/registrator_extended_test.py
@@ -19,7 +19,7 @@ def make_registrator(**ctx_overrides):
         context.options = {
             "debug": False,
             "tags": "",
-            "ip": "127.0.0.1",
+            "ip": [("127.0.0.1", None)],
             "service_prefix": None,
             "consul_host": "127.0.0.1",
             "consul_port": 8500,

--- a/tests/registrator_extended_test.py
+++ b/tests/registrator_extended_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import requests
 
+from serviceregistrator import ServiceIP
 from serviceregistrator.registrator import (
     ServiceRegistrator,
     ConsulConnectionError,
@@ -19,7 +20,7 @@ def make_registrator(**ctx_overrides):
         context.options = {
             "debug": False,
             "tags": "",
-            "ip": [("127.0.0.1", None)],
+            "ip": [ServiceIP("127.0.0.1")],
             "service_prefix": None,
             "consul_host": "127.0.0.1",
             "consul_port": 8500,

--- a/tests/registrator_test.py
+++ b/tests/registrator_test.py
@@ -54,8 +54,15 @@ class TestIsOurIdentifier(unittest.TestCase):
         self.assertTrue(yes)
         self.assertIsNone(comment)
 
-    def test_4elems_same_hostname_same_prefix_no_udp(self):
-        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z:hhh", prefix="abc")
+    def test_4elems_same_hostname_same_prefix_tag(self):
+        """A single extra suffix (IP tag or hash) is accepted."""
+        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z:physical", prefix="abc")
+        self.assertTrue(yes)
+        self.assertIsNone(comment)
+
+    def test_5elems_same_hostname_same_prefix_too_many(self):
+        """Two unknown suffixes are rejected."""
+        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z:a:b", prefix="abc")
         self.assertFalse(yes)
         self.assertEqual(comment, "unexpected suffix")
 

--- a/tests/registrator_test.py
+++ b/tests/registrator_test.py
@@ -56,13 +56,17 @@ class TestIsOurIdentifier(unittest.TestCase):
 
     def test_4elems_same_hostname_same_prefix_tag(self):
         """IP tag (after @) is stripped before parsing."""
-        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z@physical", prefix="abc")
+        yes, comment = self.registrator.is_our_identifier(
+            "abc:" + self.registrator.hostname + ":y:z@physical", prefix="abc"
+        )
         self.assertTrue(yes)
         self.assertIsNone(comment)
 
     def test_4elems_same_hostname_same_prefix_unknown_suffix(self):
         """An unknown : suffix is rejected."""
-        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z:unknown", prefix="abc")
+        yes, comment = self.registrator.is_our_identifier(
+            "abc:" + self.registrator.hostname + ":y:z:unknown", prefix="abc"
+        )
         self.assertFalse(yes)
         self.assertEqual(comment, "unexpected suffix")
 

--- a/tests/registrator_test.py
+++ b/tests/registrator_test.py
@@ -55,10 +55,16 @@ class TestIsOurIdentifier(unittest.TestCase):
         self.assertIsNone(comment)
 
     def test_4elems_same_hostname_same_prefix_tag(self):
-        """A single extra suffix (IP tag or hash) is accepted."""
-        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z:physical", prefix="abc")
+        """IP tag (after @) is stripped before parsing."""
+        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z@physical", prefix="abc")
         self.assertTrue(yes)
         self.assertIsNone(comment)
+
+    def test_4elems_same_hostname_same_prefix_unknown_suffix(self):
+        """An unknown : suffix is rejected."""
+        yes, comment = self.registrator.is_our_identifier("abc:" + self.registrator.hostname + ":y:z:unknown", prefix="abc")
+        self.assertFalse(yes)
+        self.assertEqual(comment, "unexpected suffix")
 
     def test_5elems_same_hostname_same_prefix_too_many(self):
         """Two unknown suffixes are rejected."""
@@ -74,6 +80,14 @@ class TestIsOurIdentifier(unittest.TestCase):
     def test_4elems_same_hostname_same_prefix_alias(self):
         yes, comment = self.registrator.is_our_identifier(
             "abc:" + self.registrator.hostname + ":y:z:alias", prefix="abc"
+        )
+        self.assertTrue(yes)
+        self.assertIsNone(comment)
+
+    def test_alias_with_tag(self):
+        """alias:alias@tag — both :alias and @tag are handled."""
+        yes, comment = self.registrator.is_our_identifier(
+            "abc:" + self.registrator.hostname + ":y:z:alias@physical", prefix="abc"
         )
         self.assertTrue(yes)
         self.assertIsNone(comment)

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.28.2"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -390,9 +390,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf", size = 108206, upload-time = "2023-01-12T16:24:54.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa", size = 62822, upload-time = "2023-01-12T16:24:52.241Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -422,7 +422,7 @@ wheels = [
 
 [[package]]
 name = "serviceregistrator"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -440,17 +440,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=7.1.2" },
+    { name = "click", specifier = ">=8.3.2" },
     { name = "docker", specifier = ">=4.4.1" },
-    { name = "requests", specifier = ">=2.20.0" },
+    { name = "requests", specifier = ">=2.33.1" },
     { name = "urllib3", specifier = ">=1.26.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=6.2.2" },
-    { name = "pytest-cov", specifier = ">=2.11.1" },
-    { name = "ruff", specifier = ">=0.11" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ruff", specifier = ">=0.15.10" },
 ]
 
 [[package]]


### PR DESCRIPTION
The `--ip` flag sets the default address for services.
It can be specified multiple times and accepts an optional tag using the `IP@TAG` format:

```bash
serviceregistrator --ip 10.2.2.5                        # single IP, no tag
serviceregistrator --ip 10.2.2.5@physical               # single IP with tag
serviceregistrator --ip 10.2.2.5@physical --ip 10.10.10.5@virtual  # two IPs
```

The goal is to support multiple networks if needed, with containers listening on multiple IPs, so consumers can use tags to select what they need:


- DNS: `physical.myapi.service.consul`
- consul-template: `{{range service "myapi|physical"}}`
- API: `/v1/health/service/myapi?tag=physical`