### PR TITLE
Exit after 10 consecutive Docker connection failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,14 @@ Image tags:
 
 Images are automatically built and pushed using Git Workflow (in this repo).
 
+#### Restart policy
+
+Use `--restart always` (or `--restart unless-stopped`). If the Docker daemon
+restarts, the mounted `/var/run/docker.sock` becomes stale and
+ServiceRegistrator can no longer communicate with Docker. After 10 consecutive
+failed connection attempts it exits so that the container restart policy can
+re-create the container with a fresh socket mount.
+
 #### Running (Host mode):
 
 ```bash

--- a/serviceregistrator/main.py
+++ b/serviceregistrator/main.py
@@ -119,6 +119,8 @@ def main(**options):
     context = Context(options)
     delay = context.options["delay"]
     consul_connected = False
+    docker_failures = 0
+    max_docker_failures = 10
 
     try:
         import os
@@ -141,6 +143,7 @@ def main(**options):
         try:
             context.serviceregistrator = ServiceRegistrator(context)
             consul_connected = True
+            docker_failures = 0
             context.serviceregistrator.sync_with_containers()
             context.serviceregistrator.watch_events()
         except ConsulConnectionError as e:
@@ -148,8 +151,17 @@ def main(**options):
                 sleep_delay = 5
             log.error(e)
             consul_connected = False
+            docker_failures = 0
         except docker.errors.DockerException as e:
             log.error(e)
+            docker_failures += 1
+            if docker_failures >= max_docker_failures:
+                log.critical(
+                    f"Docker connection failed {docker_failures} consecutive times. "
+                    "The Docker socket mount is likely stale (Docker daemon was restarted). "
+                    "Exiting so the container restart policy can recover with a fresh mount."
+                )
+                context.kill_now = True
         except Exception as e:
             log.error(e)
             log.error(traceback.format_exc())

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,5 +1,7 @@
 import unittest
+from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
+import docker.errors
 from serviceregistrator.main import main, loglevelfmt, validate_ip
 
 
@@ -54,3 +56,58 @@ class TestMainCli(unittest.TestCase):
         result = runner.invoke(main, ["--ip", "not-an-ip"])
         assert result.exit_code != 0
         assert "invalid IP address" in result.output
+
+
+class TestStaleDockerSocketDetection(unittest.TestCase):
+    @patch("serviceregistrator.main.ServiceRegistrator")
+    @patch("serviceregistrator.main.sleep")
+    @patch("os.stat")
+    def test_exits_after_consecutive_docker_failures(self, mock_stat, mock_sleep, mock_sr_class):
+        import stat as stat_mod
+
+        mock_stat_result = MagicMock()
+        mock_stat_result.st_mode = stat_mod.S_IFSOCK | 0o660
+        mock_stat.return_value = mock_stat_result
+
+        mock_sr_class.side_effect = docker.errors.DockerException("Error while fetching server API version")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--ip", "127.0.0.1", "--dockersock", "/var/run/docker.sock"])
+
+        assert result.exit_code == 0
+        assert "Docker connection failed 10 consecutive times" in result.output or mock_sr_class.call_count == 10
+
+    @patch("serviceregistrator.main.ServiceRegistrator")
+    @patch("serviceregistrator.main.sleep")
+    @patch("os.stat")
+    def test_resets_counter_on_successful_connection(self, mock_stat, mock_sleep, mock_sr_class):
+        import stat as stat_mod
+
+        mock_stat_result = MagicMock()
+        mock_stat_result.st_mode = stat_mod.S_IFSOCK | 0o660
+        mock_stat.return_value = mock_stat_result
+
+        call_count = [0]
+
+        def side_effect(context):
+            call_count[0] += 1
+            if call_count[0] <= 5:
+                raise docker.errors.DockerException("Connection refused")
+            if call_count[0] == 6:
+                # Succeed on 6th call, resets counter; watch_events fails (counts as failure 1)
+                mock_instance = MagicMock()
+                mock_instance.sync_with_containers.return_value = None
+                mock_instance.watch_events.side_effect = docker.errors.DockerException("lost connection")
+                return mock_instance
+            # All subsequent constructor calls fail
+            raise docker.errors.DockerException("Connection refused")
+
+        mock_sr_class.side_effect = side_effect
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--ip", "127.0.0.1", "--dockersock", "/var/run/docker.sock"])
+
+        assert result.exit_code == 0
+        # 5 constructor failures + 1 success (resets counter, watch_events fails = failure 1)
+        # + 9 more constructor failures (failures 2-10) = 15 total calls
+        assert mock_sr_class.call_count == 15


### PR DESCRIPTION
When the Docker daemon restarts, the mounted `/var/run/docker.sock` becomes stale and ServiceRegistrator can no longer communicate with Docker.

This adds a failure counter that increments on each consecutive `DockerException` and resets on successful connection. After 10 consecutive failures, ServiceRegistrator exits so the container restart policy (`--restart unless-stopped`) can re-create it with a fresh socket mount.

Changes:
- `serviceregistrator/main.py`: failure counter + exit logic
- `tests/main_test.py`: tests for exit-after-failures and counter reset
- `README.md`: document restart policy recommendation