### PR TITLE
Add --ip-mode prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Options:
   -R, --debug-requests            log requests too (debug)
   -P, --service-prefix TEXT       string to prepend to all service names and
                                   IDs (testing purpose)
+  --ip-mode [tag|prefix]          how to use IP tags: 'tag' adds to Consul
+                                  tags (default), 'prefix' uses tag as service
+                                  name prefix  [default: tag]
   --help                          Show this message and exit.
 ```
 
@@ -253,6 +256,55 @@ migration path:
 Per-container overrides with `SERVICE_IP` or `SERVICE_<port>_IP` still work.
 When a container overrides its IP, the tag from the matching `--ip` entry (if
 any) is applied.
+
+### IP Mode
+
+The `--ip-mode` flag controls how IP tags (the `@TAG` part of `--ip`) are used:
+
+- **`tag`** (default): the tag is added to the service's Consul tags. All IPs
+  register under the **same service name**. Consumers filter by tag.
+- **`prefix`**: the tag is prepended to the **service name**, creating separate
+  services per tagged IP. The tag is also added to Consul tags.
+
+Prefix mode is useful when you need services on different networks to be
+independently discoverable without changing existing consumers.
+
+**Example — prefix mode:**
+
+```bash
+serviceregistrator \
+  --ip 10.2.2.24 \
+  --ip 10.10.10.24@virtual \
+  --ip-mode prefix
+```
+
+A container with `SERVICE_NAME=pgbouncer-master` listening on `0.0.0.0` would
+register:
+
+- `pgbouncer-master` at `10.2.2.24:65436`
+- `virtual-pgbouncer-master` at `10.10.10.24:65436` (tag: `virtual`)
+
+Existing consumers querying `pgbouncer-master` are unaffected. New consumers
+can query `virtual-pgbouncer-master` to reach the service on the virtual
+network.
+
+**Combining tagged and untagged IPs:**
+
+You can use the same IP address both with and without a tag:
+
+```bash
+--ip 10.10.10.24@virtual --ip 10.10.10.24
+```
+
+This registers two services: one prefixed (`virtual-pgbouncer-master`) and one
+without prefix (`pgbouncer-master`), both pointing to the same IP.
+
+**Comparison of modes:**
+
+| Mode | Service name | Tags | Use case |
+|------|-------------|------|----------|
+| `tag` | `pgbouncer-master` | `virtual`, `v2` | Consumers filter by tag (DNS: `virtual.pgbouncer-master.service.consul`) |
+| `prefix` | `virtual-pgbouncer-master` | `virtual`, `v2` | Separate service name per network, no consumer changes needed for existing services |
 
 ### Service Alias
 

--- a/serviceregistrator/containerinfo.py
+++ b/serviceregistrator/containerinfo.py
@@ -46,6 +46,7 @@ class ContainerInfo:
         hostname: str,
         service_ips: list[ServiceIP],
         tags: list[str],
+        ip_mode: str = "tag",
     ) -> None:
         self.cid = cid
         self.name = name
@@ -54,6 +55,7 @@ class ContainerInfo:
         self.hostname = hostname
         self.service_ips = service_ips
         self.ip_tag_map: dict[str, str] = {sip.ip: sip.tag for sip in service_ips if sip.tag}
+        self.ip_mode = ip_mode
         self.service_prefix: str | None = None
         self.tags = [x for x in set(tags) if x]
         self.health: str | None = None
@@ -63,7 +65,7 @@ class ContainerInfo:
         for port in ports:
             if port.ip in {"0.0.0.0", "::", ""}:
                 for sip in service_ips:
-                    self.ports.append(port._replace(ip=sip.ip))
+                    self.ports.append(port._replace(ip=sip.ip, ip_tag=sip.tag))
             else:
                 self.ports.append(port)
 
@@ -109,7 +111,13 @@ class ContainerInfo:
                 seen[name].add((port.external, port.protocol))
         return {name: len(ports) for name, ports in seen.items()}
 
-    def build_service_name(self, port: Any) -> str | None:
+    def _get_port_ip_tag(self, port: Any, ip: str) -> str | None:
+        """Get the IP tag for a port, preferring port.ip_tag over ip_tag_map."""
+        if hasattr(port, "ip_tag"):
+            return port.ip_tag
+        return self.ip_tag_map.get(ip)
+
+    def build_service_name(self, port: Any, ip: str | None = None) -> str | None:
         if self._names_count is None:
             self._names_count = self.unique_ports_count()
         name = self.get_name(port)
@@ -120,6 +128,10 @@ class ContainerInfo:
             name = f"{name}-{port.external}"
             if port.protocol != "tcp":
                 name = f"{name}-{port.protocol}"
+        if self.ip_mode == "prefix" and name:
+            ip_tag = self._get_port_ip_tag(port, ip or "")
+            if ip_tag:
+                name = ip_tag + self.SERVICE_PREFIX_NAME_SEPARATOR + name
         return name
 
     def build_service_tags(self, port: Any, ip: str) -> list[str]:
@@ -128,7 +140,7 @@ class ContainerInfo:
             tags.extend(self.tags)
         if port.protocol != "tcp":
             tags.append(port.protocol)
-        ip_tag = self.ip_tag_map.get(ip)
+        ip_tag = self._get_port_ip_tag(port, ip)
         if ip_tag:
             tags.append(ip_tag)
         return [x for x in set(tags) if x]
@@ -141,12 +153,14 @@ class ContainerInfo:
         """Return a short hash of an IP address for use in service IDs."""
         return hashlib.sha256(ip.encode()).hexdigest()[:8]
 
-    def _has_multiple_ips(self, port: Any) -> bool:
-        """Check if this (external port, protocol) is bound to multiple IPs."""
+    def _has_multiple_untagged_ips(self, port: Any) -> bool:
+        """Check if this (external port, protocol) has multiple untagged IPs."""
         count = sum(
-            1 for p in self.ports if p.external == port.external and p.protocol == port.protocol and p.ip != port.ip
+            1
+            for p in self.ports
+            if p.external == port.external and p.protocol == port.protocol and not getattr(p, "ip_tag", None)
         )
-        return count > 0
+        return count > 1
 
     SERVICE_ID_TAG_SEPARATOR = "@"
 
@@ -158,10 +172,10 @@ class ContainerInfo:
         if port.protocol != "tcp":
             parts.append(str(port.protocol))
         base = self.SERVICE_ID_SEPARATOR.join(parts)
-        tag = self.ip_tag_map.get(ip)
+        tag = self._get_port_ip_tag(port, ip)
         if tag:
             return base + self.SERVICE_ID_TAG_SEPARATOR + tag
-        elif self._has_multiple_ips(port):
+        elif self._has_multiple_untagged_ips(port):
             return base + self.SERVICE_ID_TAG_SEPARATOR + self._ip_hash(ip)
         return base
 
@@ -195,11 +209,11 @@ class ContainerInfo:
 
             services: dict[str, Service] = dict()
             for port in self.ports:
-                service_name = self.build_service_name(port)
+                ip = self.build_service_ip(port)
+                service_name = self.build_service_name(port, ip)
                 if service_name is None:
                     log.info(f"Skipping port {port}, no service name set")
                     continue
-                ip = self.build_service_ip(port)
                 service_id = self.build_service_id(port, ip)
                 if service_id in services:
                     log.warning(f"Service ID already exists: {service_id} ({self})")

--- a/serviceregistrator/main.py
+++ b/serviceregistrator/main.py
@@ -114,6 +114,13 @@ POSSIBLE_LEVELS = (
 @click.option(
     "-P", "--service-prefix", help="string to prepend to all service names and IDs (testing purpose)", default=None
 )
+@click.option(
+    "--ip-mode",
+    help="how to use IP tags: 'tag' adds to Consul tags (default), 'prefix' uses tag as service name prefix",
+    type=click.Choice(["tag", "prefix"], case_sensitive=False),
+    default="tag",
+    show_default=True,
+)
 def main(**options):
     """Register docker containers as consul services"""
     context = Context(options)

--- a/serviceregistrator/registrator.py
+++ b/serviceregistrator/registrator.py
@@ -102,7 +102,7 @@ SERVICE_KEYVAL_REGEX = re.compile(r"SERVICE_(?P<key>[^=]+)=(?P<value>.*)$")
 SERVICE_NAME_REGEX = re.compile(r"^[\w_-]+$")
 SERVICE_TAG_REGEX = re.compile(r"^\s*(?P<tag>[\w_-]+)\s*$")
 
-Ports = namedtuple("Ports", ("internal", "external", "protocol", "ip"))
+Ports = namedtuple("Ports", ("internal", "external", "protocol", "ip", "ip_tag"), defaults=(None,))
 
 
 class ServiceRegistrator:
@@ -371,7 +371,15 @@ class ServiceRegistrator:
         name = container.name
         tags = self.parse_tags_string(container, self.context.options["tags"])
         container_info = ContainerInfo(
-            cid, name, ports, metadata, metadata_with_port, self.hostname, self.context.options["ip"], tags
+            cid,
+            name,
+            ports,
+            metadata,
+            metadata_with_port,
+            self.hostname,
+            self.context.options["ip"],
+            tags,
+            ip_mode=self.context.options.get("ip_mode", "tag"),
         )
         if self.context.options["service_prefix"]:
             container_info.service_prefix = self.context.options["service_prefix"]

--- a/tests/containerinfo_extended_test.py
+++ b/tests/containerinfo_extended_test.py
@@ -116,7 +116,7 @@ class TestServicesDuplicateName(unittest.TestCase):
             [],
         )
         # Monkey-patch build_service_name to always return the same name
-        ci.build_service_name = lambda port: "svc"
+        ci.build_service_name = lambda port, ip=None: "svc"
         services = ci.services
         assert len(services) == 2
         # Both have the same name but different IDs

--- a/tests/ip_mode_prefix_test.py
+++ b/tests/ip_mode_prefix_test.py
@@ -1,0 +1,139 @@
+import unittest
+from serviceregistrator import ContainerMetadata, ServiceIP
+from serviceregistrator.containerinfo import ContainerInfo
+from serviceregistrator.registrator import Ports
+
+
+class TestIpModePrefix(unittest.TestCase):
+    """Tests for --ip-mode prefix: IP tag becomes service name prefix."""
+
+    def test_prefix_mode_prepends_tag_to_name(self):
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.10.10.24", "virtual")],
+            [],
+            ip_mode="prefix",
+        )
+        svc = ci.services[0]
+        assert svc.name == "virtual-pgbouncer-master"
+
+    def test_prefix_mode_tag_still_in_consul_tags(self):
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.10.10.24", "virtual")],
+            [],
+            ip_mode="prefix",
+        )
+        svc = ci.services[0]
+        assert "virtual" in svc.tags
+
+    def test_prefix_mode_no_tag_no_prefix(self):
+        """IP without a tag should not add any prefix."""
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.10.10.24")],
+            [],
+            ip_mode="prefix",
+        )
+        svc = ci.services[0]
+        assert svc.name == "pgbouncer-master"
+
+    def test_tag_mode_does_not_prefix_name(self):
+        """Default tag mode should NOT prefix the service name."""
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.10.10.24", "virtual")],
+            [],
+            ip_mode="tag",
+        )
+        svc = ci.services[0]
+        assert svc.name == "pgbouncer-master"
+        assert "virtual" in svc.tags
+
+    def test_prefix_mode_two_ips_same_address_one_tagged(self):
+        """--ip 10.10.10.24@virtual --ip 10.10.10.24 produces two services."""
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.10.10.24", "virtual"), ServiceIP("10.10.10.24")],
+            [],
+            ip_mode="prefix",
+        )
+        services = ci.services
+        names = sorted(s.name for s in services)
+        assert names == ["pgbouncer-master", "virtual-pgbouncer-master"]
+
+    def test_prefix_mode_two_different_ips_both_tagged(self):
+        """Two IPs with different tags produce two prefixed services."""
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.2.2.24", "physical"), ServiceIP("10.10.10.24", "virtual")],
+            [],
+            ip_mode="prefix",
+        )
+        services = ci.services
+        names = sorted(s.name for s in services)
+        assert names == ["physical-pgbouncer-master", "virtual-pgbouncer-master"]
+
+    def test_prefix_mode_service_id_still_has_tag(self):
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.10.10.24", "virtual")],
+            [],
+            ip_mode="prefix",
+        )
+        svc = ci.services[0]
+        assert "@virtual" in svc.id
+
+    def test_prefix_mode_untagged_ip_keeps_stable_id(self):
+        """Untagged IP service ID has no hash/tag suffix — stays stable when adding a tagged IP."""
+        ci = ContainerInfo(
+            "cid",
+            "cname",
+            [Ports(internal=80, external=8080, protocol="tcp", ip="0.0.0.0")],
+            ContainerMetadata({"name": "pgbouncer-master"}),
+            {},
+            "host",
+            [ServiceIP("10.2.2.24"), ServiceIP("10.10.10.24", "virtual")],
+            [],
+            ip_mode="prefix",
+        )
+        services = {s.name: s for s in ci.services}
+        # Untagged service keeps the plain ID (no @hash, no @tag)
+        assert services["pgbouncer-master"].id == "host:cname:8080"
+        # Tagged service gets @virtual
+        assert services["virtual-pgbouncer-master"].id == "host:cname:8080@virtual"


### PR DESCRIPTION
## Summary

Adds a new `--ip-mode` CLI option that controls how IP tags (`@TAG` in `--ip IP@TAG`) are used:

- **`tag`** (default): existing behavior — tag is added to Consul tags
- **`prefix`**: tag is prepended to the service name (e.g., `virtual-pgbouncer-master`)

## Use case

When services listen on `0.0.0.0` and are reachable on multiple networks (e.g., `10.2.2.x` physical and `10.10.10.x` virtual), prefix mode allows registering them under separate names per network without disrupting existing consumers.

Example:
```bash
serviceregistrator --ip 10.2.2.24 --ip 10.10.10.24@virtual --ip-mode prefix
```

Registers:
- `pgbouncer-master` at `10.2.2.24:65436`
- `virtual-pgbouncer-master` at `10.10.10.24:65436` (tag: `virtual`)

## Key behaviors

- Tag is also added to Consul tags in prefix mode (prepares for future tag-based filtering)
- Untagged IPs keep their service ID stable — no deregistration on upgrade
- Same IP can appear with and without tag (`--ip X@tag --ip X`), producing two services
- Default mode (`tag`) is fully backward compatible

## Testing

- 8 new tests in `tests/ip_mode_prefix_test.py`
- All 226 existing tests pass
- Linter clean